### PR TITLE
Uninstall damages weewx.conf

### DIFF
--- a/install.py
+++ b/install.py
@@ -34,15 +34,6 @@ def loader():
 
 
 WLL_CONFIG = """
-[Station]
-    # This section is for information about the station.
-
-    # Set to type of station hardware. There must be a corresponding stanza
-    # in this file, which includes a value for the 'driver' option.
-    station_type = WeatherLinkLive
-
-##############################################################################
-
 [WeatherLinkLive]
     # This section configures the WeatherLink Live driver.
 


### PR DESCRIPTION
If you install your extension, then immediately uninstall it, you will damage the `weewx.conf` configuration file because the section `[Station]` will be removed.

The reason is that `[Station]` is included in the installer instructions. It thinks that it is a section installed by your extension, and should therefore be removed when the section is uninstalled.

Including it is not necessary. The station type should be set by `weectl station reconfigure`, not by the installer.