### PR TITLE
Release v1.1.6

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright © 2020-2021 Michael Schantl
+Copyright © 2020-2025 Michael Schantl and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/bin/user/weatherlink_live/__init__.py
+++ b/bin/user/weatherlink_live/__init__.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/callback.py
+++ b/bin/user/weatherlink_live/callback.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/config_editor.py
+++ b/bin/user/weatherlink_live/config_editor.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/configuration.py
+++ b/bin/user/weatherlink_live/configuration.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/configurator.py
+++ b/bin/user/weatherlink_live/configurator.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/data_host.py
+++ b/bin/user/weatherlink_live/data_host.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/davis_broadcast.py
+++ b/bin/user/weatherlink_live/davis_broadcast.py
@@ -64,6 +64,8 @@ class WllBroadcastReceiver(object):
                     continue
 
                 data, source_addr = self.sock.recvfrom(2048)
+                if self.broadcasting_wl_host != source_addr[0]:
+                    continue
                 log.debug("Received %d bytes from %s" % (len(data), source_addr))
                 try:
                     json_data = json.loads(data.decode("utf-8"))

--- a/bin/user/weatherlink_live/davis_broadcast.py
+++ b/bin/user/weatherlink_live/davis_broadcast.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/davis_http.py
+++ b/bin/user/weatherlink_live/davis_http.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/db_schema.py
+++ b/bin/user/weatherlink_live/db_schema.py
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 import weewx.units
-from schemas import wview_extended
+from weewx.schemas import wview_extended
 
 _temperature_fields = ["dewpoint2",
                        "dewpoint3",

--- a/bin/user/weatherlink_live/db_schema.py
+++ b/bin/user/weatherlink_live/db_schema.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/driver.py
+++ b/bin/user/weatherlink_live/driver.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/mappers.py
+++ b/bin/user/weatherlink_live/mappers.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/packets.py
+++ b/bin/user/weatherlink_live/packets.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/scheduler.py
+++ b/bin/user/weatherlink_live/scheduler.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/scheduler.py
+++ b/bin/user/weatherlink_live/scheduler.py
@@ -22,7 +22,7 @@ import logging
 import sched
 import threading
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from math import floor
 from typing import Optional, Callable
 
@@ -37,7 +37,7 @@ log = logging.getLogger(__name__)
 def _format_iso(ts: Optional[float]) -> Optional[str]:
     if ts is None:
         return None
-    return datetime.utcfromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S Z')
+    return datetime.fromtimestamp(ts, UTC).strftime('%Y-%m-%d %H:%M:%S Z')
 
 
 class Scheduler(object):

--- a/bin/user/weatherlink_live/service.py
+++ b/bin/user/weatherlink_live/service.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/static/__init__.py
+++ b/bin/user/weatherlink_live/static/__init__.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/static/config.py
+++ b/bin/user/weatherlink_live/static/config.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/static/labels.py
+++ b/bin/user/weatherlink_live/static/labels.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/static/packets.py
+++ b/bin/user/weatherlink_live/static/packets.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/static/targets.py
+++ b/bin/user/weatherlink_live/static/targets.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/static/version.py
+++ b/bin/user/weatherlink_live/static/version.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live/utils.py
+++ b/bin/user/weatherlink_live/utils.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/bin/user/weatherlink_live_driver.py
+++ b/bin/user/weatherlink_live_driver.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal

--- a/changes.md
+++ b/changes.md
@@ -237,3 +237,12 @@ Driver is now compatible with **Python 3.7 or later**.
 
   Rain rate is accumulated by using maximum value for consistency
   with WeatherLink app/dashboard.
+
+
+## Version 1.1.6
+
+- **Fix changed module import for database schema** ([#53](https://github.com/michael-slx/weewx-weatherlink-live/issues/53))
+
+  Database schemas were moved to a different module in WeeWX 5.2.0
+
+- **Fix usage of deprecated `utcfromtimestamp()` method**

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -32,7 +32,7 @@ If you haven't done so already, install the following packages:
 1. Install the extension by running the following command, possibly using `sudo`.
 
 ```sh
-> weectl extension install https://github.com/michael-slx/weewx-weatherlink-live/releases/download/v1.1.5/weewx-weatherlink-live-v1.1.5.tar.xz
+> weectl extension install https://github.com/michael-slx/weewx-weatherlink-live/releases/download/v1.1.6/weewx-weatherlink-live-v1.1.6.tar.xz
 ```
 
 Answer `y` (Yes), when asked if you want to install the extension.

--- a/install.py
+++ b/install.py
@@ -74,7 +74,7 @@ class WeatherLinkLiveInstaller(ExtensionInstaller):
     def __init__(self):
         super(WeatherLinkLiveInstaller, self).__init__(
             name='weatherlink-live',
-            version="1.1.5",
+            version="1.1.6",
             description='WeeWX driver for Davis WeatherLink Live.',
             author="Michael Schantl",
             author_email="floss@schantl-lx.at",

--- a/install.py
+++ b/install.py
@@ -1,4 +1,4 @@
-# Copyright © 2020-2024 Michael Schantl and contributors
+# Copyright © 2020-2025 Michael Schantl and contributors
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Version 1.1.6

- **Fix changed module import for database schema** ([#53](https://github.com/michael-slx/weewx-weatherlink-live/issues/53))

  Database schemas were moved to a different module in WeeWX 5.2.0

- **Fix usage of deprecated `utcfromtimestamp()` method**
